### PR TITLE
Remove redundant tags from mail template

### DIFF
--- a/share-message-body.tpl.php
+++ b/share-message-body.tpl.php
@@ -10,19 +10,16 @@
  * http://www.anandgraves.com/html-email-guide#effective_layout
  */
 ?>
-<html>
-  <body>
-    <table width="400px" cellspacing="0" cellpadding="10" border="0">
-      <tbody>
-        <tr>
-          <td style="font-family:Arial,Helvetica,sans-serif; font-size:12px;">
-            <?php if ($values['message']): ?>
-            <p><?php print t('Message from Sender'); ?></p><p><?php print $values['message']; ?></p>
-            <?php endif; ?>
-            <?php echo $values['footer']; ?>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </body>
-</html>
+
+<table width="400px" cellspacing="0" cellpadding="10" border="0">
+  <tbody>
+    <tr>
+      <td style="font-family:Arial,Helvetica,sans-serif; font-size:12px;">
+        <?php if ($values['message']): ?>
+        <p><?php print t('Message from Sender'); ?></p><p><?php print $values['message']; ?></p>
+        <?php endif; ?>
+        <?php echo $values['footer']; ?>
+      </td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
As the comment suggests, the mail template should only contain the content of the email body. The way it is now, a second html and body tag are added inside a div within the body of the email.