### PR TITLE
Twitter: Omit url parameter if [share:url] token occurs in the text.

### DIFF
--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -52,7 +52,7 @@ class Twitter extends ChannelBase {
    */
   public function render() {
     $data = $this->generateTokenData('twitter_share');
-    $text_includes_url = strpos($this->options['text'], '[share:url]');
+    $text_includes_url = strpos($this->options['text'], '[share:url]') !== FALSE;
     $text = token_replace($this->options['text'], $data);
 
     return array(

--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -52,6 +52,7 @@ class Twitter extends ChannelBase {
    */
   public function render() {
     $data = $this->generateTokenData('twitter_share');
+    $text_includes_url = strpos($this->options['text'], '[share:url]');
     $text = token_replace($this->options['text'], $data);
 
     return array(
@@ -59,7 +60,7 @@ class Twitter extends ChannelBase {
       'href' => 'http://twitter.com/share',
       'query' => [
         'text' => $text,
-        'url' => $this->generateShareUrl('twitter_share'),
+        'url' => !$text_includes_url ? $this->generateShareUrl('twitter_share') : '',
       ],
       'attributes' => array(
         'title' => t('Share this via Twitter!'),

--- a/src/WhatsApp.php
+++ b/src/WhatsApp.php
@@ -50,7 +50,11 @@ class WhatsApp extends ChannelBase {
    */
   public function render() {
     $data = $this->generateTokenData('whatsapp_share');
-    $text = token_replace($this->options['text'], $data);
+    $text = $this->options['text'];
+    if (strpos($text, '[share:url]') === FALSE) {
+      $text .= ' [share:url]';
+    }
+    $text = token_replace($text, $data);
 
     return [
       'title' => $this->title(),

--- a/tests/TwitterTest.php
+++ b/tests/TwitterTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Drupal\share_light;
+
+use Upal\DrupalUnitTestCase;
+
+/**
+ * Test the twitter share link.
+ */
+class TwitterTest extends DrupalUnitTestCase {
+
+  /**
+   * Test rendering the link with node.
+   */
+  public function testRenderLink() {
+    $block = $this->createMock(Block::class);
+    $node = (object) [
+      'nid' => 42,
+    ];
+    $block->method('getShareNode')->willReturn($node);
+    $block->method('getLink')->willReturn([
+      'path' => 'node/42',
+    ]);
+    $channel = new Twitter($block, [
+      'text' => 'Share text.',
+    ]);
+    $link = $channel->render();
+    $text = $link['query']['text'];
+    $url = $link['query']['url'];
+    $this->assertNotEmpty($url);
+    $this->assertContains('node/42', $url);
+    $this->assertNotContains($url, $text);
+    $this->assertEqual('Share text.', $text);
+  }
+
+  /**
+   * Test rendering the link with node when [share:url] is part of the text.
+   */
+  public function testRenderWithShareToken() {
+    $block = $this->createMock(Block::class);
+    $node = (object) [
+      'nid' => 42,
+    ];
+    $block->method('getShareNode')->willReturn($node);
+    $block->method('getLink')->willReturn([
+      'path' => 'node/42',
+    ]);
+    $channel = new Twitter($block, [
+      'text' => 'Text with [share:url].',
+    ]);
+    $link = $channel->render();
+    $text = $link['query']['text'];
+    $url = $link['query']['url'];
+    $this->assertEmpty($url);
+  }
+
+}

--- a/tests/TwitterTest.php
+++ b/tests/TwitterTest.php
@@ -10,9 +10,9 @@ use Upal\DrupalUnitTestCase;
 class TwitterTest extends DrupalUnitTestCase {
 
   /**
-   * Test rendering the link with node.
+   * Create a mock block.
    */
-  public function testRenderLink() {
+  protected function mockBlock() {
     $block = $this->createMock(Block::class);
     $node = (object) [
       'nid' => 42,
@@ -21,7 +21,14 @@ class TwitterTest extends DrupalUnitTestCase {
     $block->method('getLink')->willReturn([
       'path' => 'node/42',
     ]);
-    $channel = new Twitter($block, [
+    return $block;
+  }
+
+  /**
+   * Test rendering the link with node.
+   */
+  public function testRenderLink() {
+    $channel = new Twitter($this->mockBlock(), [
       'text' => 'Share text.',
     ]);
     $link = $channel->render();
@@ -37,15 +44,7 @@ class TwitterTest extends DrupalUnitTestCase {
    * Test rendering the link with node when [share:url] is part of the text.
    */
   public function testRenderWithShareToken() {
-    $block = $this->createMock(Block::class);
-    $node = (object) [
-      'nid' => 42,
-    ];
-    $block->method('getShareNode')->willReturn($node);
-    $block->method('getLink')->willReturn([
-      'path' => 'node/42',
-    ]);
-    $channel = new Twitter($block, [
+    $channel = new Twitter($this->mockBlock(), [
       'text' => 'Text with [share:url].',
     ]);
     $link = $channel->render();

--- a/tests/WhatsAppTest.php
+++ b/tests/WhatsAppTest.php
@@ -5,9 +5,9 @@ namespace Drupal\share_light;
 use Upal\DrupalUnitTestCase;
 
 /**
- * Test the twitter share link.
+ * Test the WhatsApp share link.
  */
-class TwitterTest extends DrupalUnitTestCase {
+class WhatsAppTest extends DrupalUnitTestCase {
 
   /**
    * Create a mock block.
@@ -25,32 +25,28 @@ class TwitterTest extends DrupalUnitTestCase {
   }
 
   /**
-   * Test rendering the link with node.
+   * Test that the share URL is appended to the text if the token is missing.
    */
-  public function testRenderLink() {
-    $channel = new Twitter($this->mockBlock(), [
+  public function testShareUrlGetsAppended() {
+    $channel = new WhatsApp($this->mockBlock(), [
       'text' => 'Share text.',
     ]);
     $link = $channel->render();
     $text = $link['query']['text'];
-    $url = $link['query']['url'];
-    $this->assertNotEmpty($url);
-    $this->assertContains('node/mock-nid', $url);
-    $this->assertNotContains($url, $text);
-    $this->assertEqual('Share text.', $text);
+    $this->assertContains('node/mock-nid', $text);
   }
 
   /**
    * Test rendering the link with node when [share:url] is part of the text.
    */
   public function testRenderWithShareToken() {
-    $channel = new Twitter($this->mockBlock(), [
+    $channel = new WhatsApp($this->mockBlock(), [
       'text' => 'Text with [share:url].',
     ]);
     $link = $channel->render();
     $text = $link['query']['text'];
-    $url = $link['query']['url'];
-    $this->assertEmpty($url);
+    $this->assertContains('node/mock-nid', $text);
+    $this->assertEqual('.', substr($text, -1));
   }
 
 }


### PR DESCRIPTION
If present the `url=`-query parameter adds the URL to the end of the tweet. If we also include the URL in the text this means the URL appears twice. Since `[share:url]` is the default text we probably don’t want to do that.