### PR TITLE
Fix missing protocols

### DIFF
--- a/share_light.install
+++ b/share_light.install
@@ -65,6 +65,7 @@ function share_light_install() {
   $field->save();
 
   variable_set('share_light_channels_enabled', _share_light_default_channels());
+  _share_light_add_protocols();
 }
 
 function share_light_uninstall() {
@@ -107,9 +108,9 @@ function _share_light_default_channels() {
 }
 
 /**
- * Allow proprietary share url protocols in links.
+ * Add proprietary share url protocols to allowed protocols.
  */
-function share_light_update_7201() {
+function _share_light_add_protocols() {
   $share_protocols = [
     'fb-messenger',
     'whatsapp',
@@ -133,6 +134,13 @@ function share_light_update_7201() {
   $allowed_protocols = variable_get('filter_allowed_protocols', $defaults);
   $allowed_protocols = array_unique(array_merge($allowed_protocols, $share_protocols));
   variable_set('filter_allowed_protocols', $allowed_protocols);
+}
+
+/**
+ * Allow proprietary share url protocols in links.
+ */
+function share_light_update_7201() {
+  _share_light_add_protocols();
 }
 
 /**

--- a/share_light.install
+++ b/share_light.install
@@ -107,6 +107,35 @@ function _share_light_default_channels() {
 }
 
 /**
+ * Allow proprietary share url protocols in links.
+ */
+function share_light_update_7201() {
+  $share_protocols = [
+    'fb-messenger',
+    'whatsapp',
+  ];
+  // Defaults copied from drupal_strip_dangerous_protocols().
+  $defaults = [
+    'ftp',
+    'http',
+    'https',
+    'irc',
+    'mailto',
+    'news',
+    'nntp',
+    'rtsp',
+    'sftp',
+    'ssh',
+    'tel',
+    'telnet',
+    'webcal',
+  ];
+  $allowed_protocols = variable_get('filter_allowed_protocols', $defaults);
+  $allowed_protocols = array_unique(array_merge($allowed_protocols, $share_protocols));
+  variable_set('filter_allowed_protocols', $allowed_protocols);
+}
+
+/**
  * Add text_format columns to share_light_email_settings.
  */
 function share_light_update_7101() {

--- a/tests/ShareUrlTest.php
+++ b/tests/ShareUrlTest.php
@@ -34,26 +34,26 @@ class ShareUrlTest extends \DrupalUnitTestCase {
     $this->assertEquals('node/' . $node->nid . '/share', $email['href']);
     $this->assertEquals('/node/' . $node->nid, $email['query']['path']);
     $this->assertEquals('https://www.facebook.com/sharer.php', $fb['href']);
-    $this->assertContains('node/' . $node->nid, $fb['query']['u']);
+    $this->assertStringContainsString('node/' . $node->nid, $fb['query']['u']);
 
     $this->assertEquals('http://twitter.com/share', $twitter['href']);
-    $this->assertContains('node/' . $node->nid, $twitter['query']['text']);
-    $this->assertContains('utm_campaign=%5B' . $node->nid . '%5D', $twitter['query']['text']);
+    $this->assertStringContainsString('node/' . $node->nid, $twitter['query']['text']);
+    $this->assertStringContainsString('utm_campaign=%5B' . $node->nid . '%5D', $twitter['query']['text']);
 
     $this->assertEquals('fb-messenger://share', $fb_msg['href']);
     $this->assertEquals(TRUE, $fb_msg['external']);
-    $this->assertContains('node/' . $node->nid, $fb_msg['query']['link']);
+    $this->assertStringContainsString('node/' . $node->nid, $fb_msg['query']['link']);
 
     $this->assertEquals('whatsapp://send', $whatsapp['href']);
     $this->assertEquals(TRUE, $whatsapp['external']);
-    $this->assertContains('node/' . $node->nid, $whatsapp['query']['text']);
-    $this->assertContains('utm_campaign=%5B' . $node->nid . '%5D', $whatsapp['query']['text']);
+    $this->assertStringContainsString('node/' . $node->nid, $whatsapp['query']['text']);
+    $this->assertStringContainsString('utm_campaign=%5B' . $node->nid . '%5D', $whatsapp['query']['text']);
 
     $this->assertEquals('mailto:', $mailto['href']);
     $this->assertEquals(TRUE, $mailto['external']);
-    $this->assertContains($node->title, $mailto['query']['subject']);
-    $this->assertContains('node/' . $node->nid, $mailto['query']['body']);
-    $this->assertContains('utm_campaign=%5B' . $node->nid . '%5D', $mailto['query']['body']);
+    $this->assertStringContainsString($node->title, $mailto['query']['subject']);
+    $this->assertStringContainsString('node/' . $node->nid, $mailto['query']['body']);
+    $this->assertStringContainsString('utm_campaign=%5B' . $node->nid . '%5D', $mailto['query']['body']);
   }
 
 }

--- a/tests/TwitterTest.php
+++ b/tests/TwitterTest.php
@@ -35,8 +35,8 @@ class TwitterTest extends DrupalUnitTestCase {
     $text = $link['query']['text'];
     $url = $link['query']['url'];
     $this->assertNotEmpty($url);
-    $this->assertContains('node/mock-nid', $url);
-    $this->assertNotContains($url, $text);
+    $this->assertStringContainsString('node/mock-nid', $url);
+    $this->assertStringNotContainsString($url, $text);
     $this->assertEqual('Share text.', $text);
   }
 

--- a/tests/WhatsAppTest.php
+++ b/tests/WhatsAppTest.php
@@ -49,4 +49,16 @@ class WhatsAppTest extends DrupalUnitTestCase {
     $this->assertEqual('.', substr($text, -1));
   }
 
+  /**
+   * Test rendering the link does not strip the protocol.
+   *
+   * Test that the 'filter_allowed_protocols' variable includes 'whatsapp'.
+   */
+  public function testRenderWithProtocol() {
+    $channel = new WhatsApp($this->mockBlock());
+    $link = $channel->render();
+    $rendered_link = l($link['title'], $link['href'], $link);
+    $this->assertStringContainsString($link['href'], $rendered_link);
+  }
+
 }

--- a/tests/WhatsAppTest.php
+++ b/tests/WhatsAppTest.php
@@ -33,7 +33,7 @@ class WhatsAppTest extends DrupalUnitTestCase {
     ]);
     $link = $channel->render();
     $text = $link['query']['text'];
-    $this->assertContains('node/mock-nid', $text);
+    $this->assertStringContainsString('node/mock-nid', $text);
   }
 
   /**
@@ -45,7 +45,7 @@ class WhatsAppTest extends DrupalUnitTestCase {
     ]);
     $link = $channel->render();
     $text = $link['query']['text'];
-    $this->assertContains('node/mock-nid', $text);
+    $this->assertStringContainsString('node/mock-nid', $text);
     $this->assertEqual('.', substr($text, -1));
   }
 


### PR DESCRIPTION
Drupal now strips proprietary share protocols from links, see https://www.drupal.org/node/3307791